### PR TITLE
feat(config): separate S3 and SES AWS credentials

### DIFF
--- a/api_mysql/config.py
+++ b/api_mysql/config.py
@@ -5,15 +5,22 @@ password = os.environ["PASSWORD"]
 host = os.environ["HOST"]
 port = os.environ["DB_PORT"]
 database = os.environ["DATABASE"]
-SECRET_KEY = os.environ["SECRET_KEY"]
-AWS_REGION = os.environ["AWS_REGION"]
-AWS_ACCESS_KEY_ID = os.environ["AWS_ACCESS_KEY_ID"]
-AWS_SECRET_ACCESS_KEY = os.environ["AWS_SECRET_ACCESS_KEY"]
-GOOGLE_API_KEY = os.environ["GOOGLE_API_KEY"]
-API_BASE_URL = os.environ["API_BASE_URL"]
-
-S3_BUCKET_QMONKEY = os.environ.get("S3_BUCKET_QMONKEY", "qmonkey.drunagor.app")
 
 DATABASE_URI = (
     f"mysql+pymysql://{user}:{password}@{host}:{port}/{database}?charset=utf8mb4"
 )
+
+SECRET_KEY = os.environ["SECRET_KEY"]
+GOOGLE_API_KEY = os.environ["GOOGLE_API_KEY"]
+API_BASE_URL = os.environ["API_BASE_URL"]
+
+# AWS S3 (assets)
+AWS_S3_REGION = os.environ.get("AWS_S3_REGION")
+AWS_S3_ACCESS_KEY_ID = os.environ.get("AWS_S3_ACCESS_KEY_ID")
+AWS_S3_SECRET_ACCESS_KEY = os.environ.get("AWS_S3_SECRET_ACCESS_KEY")
+S3_BUCKET = os.environ.get("S3_BUCKET")
+
+# AWS SES (@wearecgs.com)
+AWS_REGION = os.environ["AWS_REGION"]
+AWS_ACCESS_KEY_ID = os.environ["AWS_ACCESS_KEY_ID"]
+AWS_SECRET_ACCESS_KEY = os.environ["AWS_SECRET_ACCESS_KEY"]


### PR DESCRIPTION
- Add dedicated S3 credentials (AWS_S3_*) for assets management
- Keep SES credentials (AWS_*) for email sending
- Remove hardcoded credentials from config file
- All sensitive data now loaded from environment variables